### PR TITLE
[aws] Add AWS Amplify configuration file

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,15 @@
+version: 0.1
+￼frontend:
+￼  phases:
+￼    preBuild:
+￼      commands:
+￼        - rvm --default use $VERSION_RUBY_2_6
+￼        - gem install bundler
+￼        - bundler
+￼    build:
+￼      commands:
+￼        - jekyll build
+￼  artifacts:
+￼    baseDirectory: _site
+￼    files:
+￼      - '**/*'


### PR DESCRIPTION
Unfortunately Jekyll's official Docker container (ref:
https://github.com/envygeeks/jekyll-docker/blob/master/README.md)
utilises Alpine as its "base" making it incompatible as a custom AWS
Amplify build image (ref:
aws-amplify/amplify-hosting#100 (comment)).

Instead the official AWS 'Amazon Linux:2' "default" Docker container (ref:
https://github.com/aws-amplify/amplify-hosting/blob/main/images/latest/Dockerfile)
is utilised as the build image.

While AWS Amplify provides "Live Package updates" for use in thier
"default" Docker build images (ref:
https://docs.aws.amazon.com/amplify/latest/userguide/custom-build-image.html)
Ruby's "Gem" management tool, 'bundler', is explicitly updated (against
the repository's Gemfile) as part of the 'preBuild' phase. The rationale
here being to explicitly surface build time configuration and avoid "outside
repository"/external configuration/behaviour.

AWS Amplify build specification YAML syntax reference:
https://docs.aws.amazon.com/amplify/latest/userguide/build-settings.html