### PR TITLE
[amplify] Version lock 'bundler' to v2.3.20

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ frontend:
     preBuild:
       commands:
         - rvm --default use $VERSION_RUBY_2_6
-        - gem install bundler
+        - gem install bundler --version 2.3.20
         - bundler
     build:
       commands:


### PR DESCRIPTION
Recent updates of the Ruby Gem dependency management utility, 'bundler', introduced a breakage to the 'jekyll-theme-chirpy' Ruby Gem starting from version v2.3.21: https://github.com/rubygems/rubygems/pull/4488

```
2022-12-03T02:23:00.509Z [WARNING]: Could not find gem
'jekyll-theme-chirpy (~> 5.2, >= 5.2.1)' with platform
                                    'x86_64-linux' in rubygems
repository https://rubygems.org/ or installed
                                    locally.
                                    The source contains the following
gems matching 'jekyll-theme-chirpy (~> 5.2, >=
                                    5.2.1)':
                                    * jekyll-theme-chirpy-5.2.1
                                    * jekyll-theme-chirpy-5.3.0
                                    * jekyll-theme-chirpy-5.3.1
                                    * jekyll-theme-chirpy-5.3.2  
```

This commit is intended to serve as a stop-gap solution until all existing blog content has been migrated to AWS Amplify.