### PR TITLE
[ci-cd] Configure MegaLinter YAML linters

### DIFF
--- a/.linters/yaml/prettierrc.yaml
+++ b/.linters/yaml/prettierrc.yaml
@@ -1,0 +1,6 @@
+---
+printWidth: 80
+proseWrap: 'always'
+semi: false
+singleQuote: true
+tabWidth: 2

--- a/.linters/yaml/v8rrc.yaml
+++ b/.linters/yaml/v8rrc.yaml
@@ -1,0 +1,8 @@
+# - One or more filenames or glob patterns describing local file or files to validate
+# - overridden by passing one or more positional arguments
+patterns: ['.mega-linter.yml', '.linters/**/*.y?(a)ml']
+
+# - Level of verbose logging. 0 is standard, higher numbers are more verbose
+# - overridden by passing --verbose / -v
+# - default = 0
+verbose: 0

--- a/.linters/yaml/yamllint.yaml
+++ b/.linters/yaml/yamllint.yaml
@@ -1,0 +1,4 @@
+---
+# Default yamllint options: https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+# Default MegaLinter yamllint configuration file: /action/lib/.automation/.yamllint.yml
+extends: default

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -17,6 +17,9 @@ LINTER_RULES_PATH: '.linters/'
 PRINT_ALPACA: false
 PRINT_ALL_FILES: true
 
+APPLY_FIXES:
+ - YAML_PRETTIER
+
 #
 # MARKDOWN
 # https://megalinter.io/v6/descriptors/markdown/

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -9,18 +9,19 @@
 ENABLE:
   - MARKDOWN
   - SPELL
+  - YAML
 
-FILTER_REGEX_INCLUDE: '_posts/'
+FILTER_REGEX_INCLUDE: (_posts/|.linters/|.mega-linter.yml)
 LINTER_RULES_PATH: '.linters/'
 
 PRINT_ALPACA: false
 PRINT_ALL_FILES: true
 
-
 #
 # MARKDOWN
 # https://megalinter.io/v6/descriptors/markdown/
 #
+MARKDOWN_FILTER_REGEX_INCLUDE: (_posts/)
 
 # Linter name:       MarkdownLint
 # Linter version:    0.33.0
@@ -44,6 +45,7 @@ MARKDOWN_MARKDOWN_LINK_CHECK_CONFIG_FILE: 'markdown/markdown-link-check.json'
 # SPELL
 # https://megalinter.io/v6/descriptors/spell/
 #
+SPELL_FILTER_REGEX_INCLUDE: (_posts/)
 
 # Linter name:       cspell
 # Linter version:    6.18.1
@@ -61,3 +63,28 @@ SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.yaml'
 # Linter config:     https://github.com/amperser/proselint#readme
 # MegaLinter config: https://megalinter.io/latest/descriptors/spell_proselint/
 SPELL_PROSELINT_RULES_PATH: '.linters/spell/'
+
+
+#
+# YAML
+# https://megalinter.io/v6/descriptors/yaml/
+#
+YAML_FILTER_REGEX_INCLUDE: (.linters/|.mega-linter.yml)
+
+# Linter name:       prettier
+# Linter version:    2.8.1
+# Linter config:     https://prettier.io/docs/en/configuration.html
+# MegaLinter config: https://megalinter.io/v6/descriptors/yaml_prettier/
+YAML_PRETTIER_CONFIG_FILE: 'yaml/prettierrc.yaml'
+
+# Linter name:       yamllint
+# Linter version:    1.28.0
+# Linter config:     https://yamllint.readthedocs.io/en/stable/configuration.html#configuration
+# MegaLinter config: https://megalinter.io/v6/descriptors/yaml_yamllint/
+YAML_YAMLLINT_CONFIG_FILE: 'yaml/yamllint.yaml'
+
+# Linter name:       v8r
+# Linter version:    0.13.1
+# Linter config:     https://github.com/chris48s/v8r#configuration
+# MegaLinter config: https://megalinter.io/v6/descriptors/yaml_v8r/
+YAML_V8R_CLI_LINT_MODE: 'project'


### PR DESCRIPTION
MegaLinter v6's YAML "descriptor" contains 3 discrete YAML linters, all of which are utilised in the "documentation" MegaLinter v6 Docker container "flavor":
* `prettier`: https://github.com/prettier/prettier
* `yamllint`: https://github.com/adrienverge/yamllint
* `v8r`: https://github.com/chris48s/v8r

MegaLinter v6's YAML "descriptor" is **not** intended to be applied to blog Markdown posts. Instead it serves as a "meta-linter" for YAML based linter configuration files (`.linters/**/*.y{a,}ml`) in addition to verifying the global MegaLinter configuration file (`.mega-linter.yml`).  

Unlike MegaLinter v6's Spell and Markdown "descriptors" the YAML "descriptor"'s encapsulated linters support more than just the YAML data serialisation language. The `prettier` and `v8r` YAML linters differ from the current "normal" linter _configuration_ (i.e. MegaLinter's mechanism for specifying linter configuration files) and _behaviour_ (i.e. applying fixes and bundling them as a git patch). Refer to the corresponding commit messages for these linters for additional context and rationale.

Reference: https://megalinter.io/v6/descriptors/yaml/
Flavor: https://megalinter.io/v6/flavors/documentation/