### PR TITLE
[amplify] Update custom build container image ruby:3.3.0-bookworm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ JEKYLL_SERVE_OPTS ?= --host 0.0.0.0 \
                      --incremental
 
 # Baremetal environment detected, utilise container engine (CRI)
-ifeq (,$(wildcard /run/.containerenv))
+ifeq (,$(or $(wildcard /run/.containerenv),$(AWS_PLATFORM)))
     EXEC_ENV := _baremetal
 
     OCI_REGISTRY := docker.io/library

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,15 +1,13 @@
 version: 0.1
 frontend:
   phases:
-    preBuild:
-      commands:
-        - rvm --default use $VERSION_RUBY_2_6
-        - gem install bundler --version 2.3.20
-        - bundler
     build:
       commands:
-        - jekyll build
+        - make build
   artifacts:
     baseDirectory: _site
     files:
       - '**/*'
+  cache:
+    paths:
+      - vendor/**/*


### PR DESCRIPTION
Commit https://github.com/penguinspiral/jekyll-blog/commit/6e0404c87bcc708208ac5d10ea2244d1ececf5cd introduced an environment agnostic makefile which serves as the singular interface for all Jekyll operations. The makefile currently supports Jekyll operations from within the latest ("3.3.0-bookworm"), official, "defacto" Ruby OCI container/image.

AWS Amplify's "Build settings" -> "Build image settings" (via AWS console) has been configured to use the official Ruby OCI container/image instead of the default 'Amazon Linux:2' image. For cryptographic and consistency (with the makefile) purposes the SHA256 hash of the latest "defacto" OCI container/image tag '3.3.0-bookworm' has been
used: docker.io/library/ruby@sha256:c44f9bb8fedfac02c29cd7bb7e22779791b60296249c9e43dbffe85b153e795e

This PR includes:

* Adoption of the new interface in addition to actively leveraging AWS Amplify's 'cache' directive (ref: https://docs.aws.amazon.com/amplify/latest/userguide/build-settings.html).

* Definition check for the 'AWS_PLATFORM' environment variable when autodetecting the current operational environment. Coverage now includes Docker, Podman, and AWS Amplify CRI environments.