### PR TITLE
[upstream] cotes2020/chirpy-starter v6.4.2 update

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3
+          ruby-version: 3.2
           bundler-cache: true
 
       - name: Build site

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jekyll-theme-chirpy", "~> 6.4"
+gem "jekyll-theme-chirpy", "~> 6.4", ">= 6.4.1"
 
 group :test do
   gem "html-proofer", "~> 4.4"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jekyll-theme-chirpy", "~> 6.3", ">= 6.3.1"
+gem "jekyll-theme-chirpy", "~> 6.4"
 
 group :test do
   gem "html-proofer", "~> 4.4"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jekyll-theme-chirpy", "~> 6.4", ">= 6.4.1"
+gem "jekyll-theme-chirpy", "~> 6.4", ">= 6.4.2"
 
 group :test do
   gem "html-proofer", "~> 4.4"

--- a/_config.yml
+++ b/_config.yml
@@ -75,6 +75,10 @@ img_cdn:
 # the avatar on sidebar, support local or CORS resources
 avatar:
 
+# The URL of the site-wide social preview image used in SEO `og:image` meta tag.
+# It can be overridden by a customized `page.image` in front matter.
+social_preview_image: # string, local or CORS resources
+
 # boolean type, the global switch for TOC in posts.
 toc: true
 


### PR DESCRIPTION
Merging latest release, v6.4.2, of upstream repository:
https://github.com/cotes2020/chirpy-starter