### PR TITLE
[ci-cd] Sync MegaLinter 7.7.0 spell linters

### DIFF
--- a/.linters/README.md
+++ b/.linters/README.md
@@ -6,4 +6,4 @@ file(s). The layout mirrors MegaLinter's 1:"descriptor" <-> N:"linter(s)" relati
 ## Descriptors
 
 * Markdown: https://megalinter.io/latest/descriptors/markdown/
-* Spell: https://megalinter.io/latest/descriptors/spell/
+* Spell: https://megalinter.io/7.7.0/descriptors/spell/

--- a/.linters/spell/cspell/cspell.json
+++ b/.linters/spell/cspell/cspell.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+    "version": "0.2",
+    "dictionaryDefinitions": [
+        {
+            "name": "cspell-dictionary",
+            "path": "./cspell-dictionary.txt",
+            "addWords": true
+        }
+    ],
+    "dictionaries": [
+        "cspell-dictionary"
+    ]
+}

--- a/.linters/spell/cspell/cspell.yaml
+++ b/.linters/spell/cspell/cspell.yaml
@@ -1,9 +1,0 @@
----
-$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
-version: '0.2'
-dictionaryDefinitions:
-  - name: cspell-dictionary
-    path: './cspell-dictionary.txt'
-    addWords: true
-dictionaries:
-  - cspell-dictionary

--- a/.linters/spell/lychee.toml
+++ b/.linters/spell/lychee.toml
@@ -1,0 +1,14 @@
+# Inherit default configurations (v0.13.0):
+# https://github.com/lycheeverse/lychee/blob/v0.13.0/lychee.example.toml
+
+# Check links inside `<code>` and `<pre>` blocks as well as Markdown code
+# blocks.
+include_verbatim = true
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+exclude_all_private = true
+
+# Exclude all mail addresses from checking.
+exclude_mail = true

--- a/.linters/spell/vale/vale.ini
+++ b/.linters/spell/vale/vale.ini
@@ -1,0 +1,8 @@
+StylesPath = .linters-cache/spell/vale/styles
+
+MinAlertLevel = warning
+
+Packages = Google, Microsoft, RedHat, Joblint, alex, write-good, proselint
+
+[*]
+BasedOnStyles = Vale, Google, Microsoft, RedHat, Joblint, alex, write-good, proselint

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -62,6 +62,20 @@ SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.yaml'
 # MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_proselint/
 SPELL_PROSELINT_RULES_PATH: '.linters/spell/'
 
+# Linter name:       vale
+# Linter version:    2.30.0
+# Linter config:     https://github.com/errata-ai/vale
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_vale/
+SPELL_VALE_PRE_COMMANDS:
+  - command: 'vale sync'
+    cwd: 'workspace'
+SPELL_VALE_CONFIG_FILE: '.vale.ini'
+
+# Linter name:       lychee
+# Linter version:    0.13.0
+# Linter config:     https://lychee.cli.rs/#/usage/config
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_lychee/
+SPELL_LYCHEE_CONFIG_FILE: 'spell/lychee.toml'
 
 #
 # YAML

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -46,20 +46,20 @@ MARKDOWN_MARKDOWN_LINK_CHECK_CONFIG_FILE: 'markdown/markdown-link-check.json'
 
 #
 # SPELL
-# https://megalinter.io/v6/descriptors/spell/
+# https://megalinter.io/7.7.0/descriptors/spell/
 #
 SPELL_FILTER_REGEX_INCLUDE: (_posts/)
 
 # Linter name:       cspell
-# Linter version:    6.18.1
+# Linter version:    8.1.3
 # Linter config:     https://cspell.org/configuration/
-# MegaLinter config: https://megalinter.io/v6/descriptors/spell_cspell/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_cspell/
 SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.yaml'
 
 # Linter name:       proselint
 # Linter version:    0.13.0
 # Linter config:     https://github.com/amperser/proselint#readme
-# MegaLinter config: https://megalinter.io/latest/descriptors/spell_proselint/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_proselint/
 SPELL_PROSELINT_RULES_PATH: '.linters/spell/'
 
 

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -54,7 +54,7 @@ SPELL_FILTER_REGEX_INCLUDE: (_posts/)
 # Linter version:    8.1.3
 # Linter config:     https://cspell.org/configuration/
 # MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_cspell/
-SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.yaml'
+SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.json'
 
 # Linter name:       proselint
 # Linter version:    0.13.0

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -56,11 +56,6 @@ SPELL_FILTER_REGEX_INCLUDE: (_posts/)
 # MegaLinter config: https://megalinter.io/v6/descriptors/spell_cspell/
 SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.yaml'
 
-# Linter name:       misspell
-# Linter version:    0.3.4
-# Linter config:     https://github.com/client9/misspell#readme
-# MegaLinter config: https://megalinter.io/v6/descriptors/spell_misspell/
-
 # Linter name:       proselint
 # Linter version:    0.13.0
 # Linter config:     https://github.com/amperser/proselint#readme

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -61,6 +61,7 @@ SPELL_CSPELL_CONFIG_FILE: 'spell/cspell/cspell.json'
 # Linter config:     https://github.com/amperser/proselint#readme
 # MegaLinter config: https://megalinter.io/7.7.0/descriptors/spell_proselint/
 SPELL_PROSELINT_RULES_PATH: '.linters/spell/'
+SPELL_PROSELINT_CONFIG_FILE: 'proselint/config.json'
 
 # Linter name:       vale
 # Linter version:    2.30.0


### PR DESCRIPTION
MegaLinter was upgraded from 'v6' to the '7.7.0' release as part of the dedicated Makefile development: #20 

MegaLinter 7.7.0's spell "descriptor" contains 4 spell linters, all of which are utilised in the "documentation" MegaLinter 7.7.0 Docker container "flavor":

* `cspell`:        https://github.com/streetsidesoftware/cspell
* `proseline`: https://github.com/amperser/proselint
* `vale`:           https://github.com/errata-ai/vale
* `lychee`:       https://github.com/lycheeverse/lychee

The unsupported [misspell linter](https://github.com/client9/misspell#readme) was explicitly removed during this version sync.

The existing `cspell` linter had its configuration file migrated from YAML to JSON so as to address a configuration file error.

The `vale` and `lychee` linters are new introductions with this version sync. Refer to their corresponding commit messages for additional context, implementation, and rationale.

Reference: https://megalinter.io/7.7.0/descriptors/spell/