### PR TITLE
[ci-cd] Update Ruby OCI image to 3.3.4-bookworm

### DIFF
--- a/Makefile.jekyll
+++ b/Makefile.jekyll
@@ -35,7 +35,7 @@ ifeq (,$(or $(wildcard /run/.containerenv),$(AWS_PLATFORM)))
 
     OCI_REGISTRY := docker.io/library
     OCI_IMG      := ruby
-    OCI_SHA256   := c44f9bb8fedfac02c29cd7bb7e22779791b60296249c9e43dbffe85b153e795e  # 3.3.0-bookworm
+    OCI_SHA256   := d4233f4242ea25346f157709bb8417c615e7478468e2699c8e86a4e1f0156de8 # 3.3.4-bookworm
     OCI_URI      := $(OCI_REGISTRY)/$(OCI_IMG)@sha256:$(OCI_SHA256)
 
     # Container engine (CRI) autodetect


### PR DESCRIPTION
Leveraging the latest, stable, official upstream OCI image:
https://hub.docker.com/_/ruby

Verified Jekyll sub-command operations are still functional despite image update:

**clean**
```
make clean
...
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll clean 
Configuration file: /srv/jekyll/_config.yml
           Cleaner: Removing /srv/jekyll/_site...
           Cleaner: Nothing to do for /srv/jekyll/.jekyll-metadata.
           Cleaner: Removing /srv/jekyll/.jekyll-cache...
           Cleaner: Nothing to do for .sass-cache.
Exiting 'podman' container engine! All parent recipes are no-op'd...
# /usr/local/bin/bundler cache
# /usr/local/bundle/bin/jekyll clean 
$ echo $?
0
```

**deps**
```
make deps
...
Fetching gem metadata from https://rubygems.org/.........
Updating files in vendor/cache
Exiting 'podman' container engine! All parent recipes are no-op'd...
# /usr/local/bin/bundler cache
$ echo $?
0
```

**build**
```
make build
...
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll build 
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
Exiting 'podman' container engine! All parent recipes are no-op'd...
# /usr/local/bin/bundler cache
# /usr/local/bundle/bin/jekyll build 
$ echo $?
0
```

**doctor**
```
make doctor
...
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll doctor 
Configuration file: /srv/jekyll/_config.yml
           Warning: You didn't set an URL in the config file, you may encounter problems with some plugins.
           Warning: Your site URL does not seem to be absolute, check the value of `url` in your config file.
make: *** [Makefile.jekyll:95: doctor] Error 1
make[1]: *** [Makefile.jekyll:82: _baremetal] Error 2
make: *** [Makefile:24: doctor] Error 2
$ echo $?
2
```

**serve**
```
make serve
...
/usr/local/bundle/bin/jekyll serve  --host 0.0.0.0 --force_polling --incremental
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: enabled
      Generating... 
Run in verbose mode to see all warnings.
                    done in 0.374 seconds.
 Auto-regeneration: enabled for '/srv/jekyll'
    Server address: http://0.0.0.0:4000/
  Server running... press ctrl-c to stop.
```