### PR TITLE
[ci-cd] Define Jekyll Makefile target specific CRI options

### DIFF
--- a/Makefile.jekyll
+++ b/Makefile.jekyll
@@ -56,9 +56,13 @@ ifeq (,$(or $(wildcard /run/.containerenv),$(AWS_PLATFORM)))
     CRI_OPTS := --rm \
                 --tty \
                 --interactive \
-                --publish 4000:4000 \
                 --volume $(CURDIR):/srv/jekyll:rw \
                 --workdir=/srv/jekyll
+
+    # Make target specific CRI options
+    ifeq ($(MAKECMDGOALS), serve)
+        CRI_OPTS += --publish 4000:4000
+    endif
 
     ifeq ($(INTERACTIVE), true)
         INTERACTIVE_CMD := ; /bin/bash


### PR DESCRIPTION
The static `--publish` CRI option prevents multiple, simultaneous make invocations regardless of the Jekyll make target. Long running make targets such as `serve` would nonsensically block other targets such as `doctor`.

This commit introduces per-target CRI option configurability to the Jekyll Makefile therefore relaxing this constraint. The `serve` target remains a singleton due to the static host port mapping.