### PR TITLE
[ci-cd] Sync MegaLinter 7.7.0 markdown linters

### DIFF
--- a/.linters/README.md
+++ b/.linters/README.md
@@ -5,5 +5,5 @@ file(s). The layout mirrors MegaLinter's 1:"descriptor" <-> N:"linter(s)" relati
 
 ## Descriptors
 
-* Markdown: https://megalinter.io/latest/descriptors/markdown/
+* Markdown: https://megalinter.io/7.7.0/descriptors/markdown/
 * Spell: https://megalinter.io/latest/descriptors/spell/

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -22,26 +22,26 @@ APPLY_FIXES:
 
 #
 # MARKDOWN
-# https://megalinter.io/v6/descriptors/markdown/
+# https://megalinter.io/7.7.0/descriptors/markdown/
 #
 MARKDOWN_FILTER_REGEX_INCLUDE: (_posts/)
 
 # Linter name:       MarkdownLint
-# Linter version:    0.33.0
+# Linter version:    0.38.0
 # Linter config:     https://github.com/DavidAnson/markdownlint#readme
-# MegaLinter config: https://megalinter.io/v6/descriptors/markdown_markdownlint/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/markdown_markdownlint/
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: 'markdown/markdownlint.yaml'
 
 # Linter name:       markdown-link-check
-# Linter version:    3.10.3
+# Linter version:    3.11.2
 # Linter config:     https://github.com/tcort/markdown-link-check#readme
-# MegaLinter config: https://megalinter.io/v6/descriptors/markdown_markdown_link_check/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/markdown_markdown_link_check/
 MARKDOWN_MARKDOWN_LINK_CHECK_CONFIG_FILE: 'markdown/markdown-link-check.json'
 
 # Linter name:       markdown-table-formatter
-# Linter version:    1.4.0
+# Linter version:    1.5.0
 # Linter config:     https://github.com/nvuillam/markdown-table-formatter#readme
-# MegaLinter config: https://megalinter.io/v6/descriptors/markdown_markdown_table_formatter/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/markdown_markdown_table_formatter/
 
 
 #


### PR DESCRIPTION
MegaLinter was upgraded from 'v6' to the '7.7.0' release as part of the dedicated Makefile development: https://github.com/penguinspiral/jekyll-blog/pull/20

MegaLinter 7.7.0's markdown "descriptor" contains 4 markdown linters, 3 of which are utilised in the "documentation" MegaLinter 7.7.0 Docker container "flavor":

* `markdownlint`: https://github.com/DavidAnson/markdownlint
* `markdown-link-check`: https://github.com/tcort/markdown-link-check
* `markdown-table-formatter`:  https://github.com/nvuillam/markdown-table-formatter

The [remark-lint](https://megalinter.io/7.7.0/descriptors/markdown_remark_lint/) markdown linter remains disabled by MegaLinter since v6:

> "_MARKDOWN_REMARK_LINT has been temporary disabled in MegaLinter, please use a previous MegaLinter version or wait for the next one !_"

Reference: https://megalinter.io/7.7.0/descriptors/markdown/