### PR TITLE
[ci-cd] Create MegaLinter '.linters-cache/' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # MegaLinter
 !.mega-linter.yml
 !.linters
+!.linters-cache/README.md
 
 # Bundler cache
 .bundle

--- a/.linters-cache/README.md
+++ b/.linters-cache/README.md
@@ -1,0 +1,6 @@
+# About
+
+This directory is intended to cache artifacts produced by MegaLinter managed
+linter(s).
+The layout mirrors the existing MegaLinter configuration: 1:"descriptor" <-> 
+N:"linter(s)" relationship.


### PR DESCRIPTION
Certain MegaLinter managed linters, e.g. [errata-ai/vale](https://github.com/errata-ai/vale), generate and/or download artifacts as part of their configuration/usage. These artifacts should be:

* Aggressively cached for accelerating CI/CD
* Omitted from tracking in Git
* Omitted from linting

Mirroring the directory layout utilised in the MegaLinter linter configuration root directory: '.linters/'.