### PR TITLE
[ci-cd] Configure MegaLinter reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !.stylelintrc.json
 
 # MegaLinter
+megalinter-reports
 !.mega-linter.yml
 !.linters
 !.linters-cache/README.md

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -91,3 +91,17 @@ YAML_YAMLLINT_CONFIG_FILE: 'yaml/yamllint.yaml'
 # Linter config:     https://github.com/chris48s/v8r#configuration
 # MegaLinter config: https://megalinter.io/v6/descriptors/yaml_v8r/
 YAML_V8R_CLI_LINT_MODE: 'project'
+
+
+#
+# REPORTERS
+# https://megalinter.io/7.7.0/reporters/
+#
+
+# Reporter name:   IDE-config
+# Reporter config: https://megalinter.io/7.7.0/reporters/ConfigReporter/
+CONFIG_REPORTER: false
+
+# Reporter name:   E-mail
+# Reporter config: https://megalinter.io/7.7.0/reporters/EmailReporter/
+EMAIL_REPORTER: false


### PR DESCRIPTION
MegaLinter supports the generation (and corresponding configuration) of various "[reports](https://megalinter.io/7.7.0/reporters/)" _post_ linting. These reports are stored in the repository's root directory inside a dedicated directory: `megalinter-reports`.

Changes in this PR involve the following:

* Disabling two unused reporters which are enabled by default in MegaLinter v7.7.0.
* Git ignoring the generated `megalinter-reports` directory (and contents)