### PR TITLE
[ci-cd] Revert v8r YAML linter to default CLI lint mode

### DIFF
--- a/.linters/yaml/v8rrc.yaml
+++ b/.linters/yaml/v8rrc.yaml
@@ -1,7 +1,3 @@
-# - One or more filenames or glob patterns describing local file or files to validate
-# - overridden by passing one or more positional arguments
-patterns: ['.mega-linter.yml', '.linters/**/*.y?(a)ml']
-
 # - Level of verbose logging. 0 is standard, higher numbers are more verbose
 # - overridden by passing --verbose / -v
 # - default = 0

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -90,4 +90,3 @@ YAML_YAMLLINT_CONFIG_FILE: 'yaml/yamllint.yaml'
 # Linter version:    0.13.1
 # Linter config:     https://github.com/chris48s/v8r#configuration
 # MegaLinter config: https://megalinter.io/v6/descriptors/yaml_v8r/
-YAML_V8R_CLI_LINT_MODE: 'project'


### PR DESCRIPTION
MegaLinter v6 previously invoked the v8r YAML linter from within the root of the container ('/') when utilising the default '*_CLI_LINT_MODE' variable value: `list_of_files`. This behaviour forced a workaround implemented across commits: 4966028 & cd82589c.

MegaLinter v7.7.0 invokes the v8r YAML linter from within the root of the repository ('/tmp/lint') as opposed to the root of the container ('/') when utilising the default '*_CLI_LINT_MODE' value: `list_of_files`.

This behaviour has been verified as follows:

```
$ make lint MEGALINTER_OPTS="ENABLE=YAML
DISABLE_LINTERS=YAML_PRETTIER,YAML_YAMLLINT" LOG_LEVEL=debug
...
[Filters] {'name': 'YAML_V8R', 'filter_regex_include':
'(.linters/|.mega-linter.yml)', 'filter_regex_exclude_descriptor': None,
'filter_regex_exclude_linter': None, 'files_sub_directory': None,
'lint_all_files': False, 'lint_all_other_linters_files': False,
'file_extensions': ['.yml', '.yaml'], 'file_names_regex': [],
'file_names_not_ends_with': [], 'file_contains_regex': [],
'file_contains_regex_extensions': []}
YAML_V8R linter kept 6 files after applying linter filters:
- .linters/markdown/markdownlint.yaml
- .linters/spell/cspell/cspell.yaml
- .linters/yaml/prettierrc.yaml
- .linters/yaml/v8rrc.yaml
- .linters/yaml/yamllint.yaml
- .mega-linter.yml

+----MATCHING LINTERS-+------------+----------------+------------+
| Descriptor | Linter | Criteria   | Matching files | Format/Fix |
+------------+--------+------------+----------------+------------+
| YAML       | v8r    | .yml|.yaml | 6              | no         |
+------------+--------+------------+----------------+------------+
...
[v8r] command: ['v8r', '--ignore-errors',
'.linters/markdown/markdownlint.yaml',
'.linters/spell/cspell/cspell.yaml', '.linters/yaml/prettierrc.yaml',
'.linters/yaml/v8rrc.yaml', '.linters/yaml/yamllint.yaml',
'.mega-linter.yml']
[v8r] CWD: /tmp/lint
[v8r] result: 0 ℹ Loaded config file from .v8rrc.yaml
```

MegaLinter's explicit YAML linter file filter inclusion variable, 'YAML_FILTER_REGEX_INCLUDE', now passes the desired file list to the v8r YAML linter. As a result the v8r YAML linter no longer needs to locate the desired YAML files and so that configuration snippet has been removed.