### PR TITLE
[ci-cd] Sync MegaLinter 7.7.0 YAML linters

### DIFF
--- a/.linters/README.md
+++ b/.linters/README.md
@@ -7,3 +7,4 @@ file(s). The layout mirrors MegaLinter's 1:"descriptor" <-> N:"linter(s)" relati
 
 * Markdown: https://megalinter.io/latest/descriptors/markdown/
 * Spell: https://megalinter.io/latest/descriptors/spell/
+* YAML: https://megalinter.io/7.7.0/descriptors/yaml/

--- a/.linters/yaml/v8rrc.yaml
+++ b/.linters/yaml/v8rrc.yaml
@@ -1,7 +1,3 @@
-# - One or more filenames or glob patterns describing local file or files to validate
-# - overridden by passing one or more positional arguments
-patterns: ['.mega-linter.yml', '.linters/**/*.y?(a)ml']
-
 # - Level of verbose logging. 0 is standard, higher numbers are more verbose
 # - overridden by passing --verbose / -v
 # - default = 0

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -70,24 +70,24 @@ SPELL_PROSELINT_RULES_PATH: '.linters/spell/'
 
 #
 # YAML
-# https://megalinter.io/v6/descriptors/yaml/
+# https://megalinter.io/7.7.0/descriptors/yaml/
 #
 YAML_FILTER_REGEX_INCLUDE: (.linters/|.mega-linter.yml)
 
 # Linter name:       prettier
-# Linter version:    2.8.1
+# Linter version:    3.1.0
 # Linter config:     https://prettier.io/docs/en/configuration.html
-# MegaLinter config: https://megalinter.io/v6/descriptors/yaml_prettier/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/yaml_prettier/
 YAML_PRETTIER_CONFIG_FILE: 'yaml/prettierrc.yaml'
 
 # Linter name:       yamllint
-# Linter version:    1.28.0
+# Linter version:    1.33.0
 # Linter config:     https://yamllint.readthedocs.io/en/stable/configuration.html#configuration
-# MegaLinter config: https://megalinter.io/v6/descriptors/yaml_yamllint/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/yaml_yamllint/
 YAML_YAMLLINT_CONFIG_FILE: 'yaml/yamllint.yaml'
 
 # Linter name:       v8r
-# Linter version:    0.13.1
+# Linter version:    2.1.0
 # Linter config:     https://github.com/chris48s/v8r#configuration
-# MegaLinter config: https://megalinter.io/v6/descriptors/yaml_v8r/
+# MegaLinter config: https://megalinter.io/7.7.0/descriptors/yaml_v8r/
 YAML_V8R_CLI_LINT_MODE: 'project'

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -90,4 +90,3 @@ YAML_YAMLLINT_CONFIG_FILE: 'yaml/yamllint.yaml'
 # Linter version:    2.1.0
 # Linter config:     https://github.com/chris48s/v8r#configuration
 # MegaLinter config: https://megalinter.io/7.7.0/descriptors/yaml_v8r/
-YAML_V8R_CLI_LINT_MODE: 'project'


### PR DESCRIPTION
Updating YAML descriptor and existing YAML linter specific documentation references to the latest MegaLinter release: 7.7.0