### PR TITLE
[ci-cd] Update Ruby OCI image to 3.4.2-bookworm

### DIFF
--- a/Makefile.jekyll
+++ b/Makefile.jekyll
@@ -35,7 +35,7 @@ ifeq (,$(or $(wildcard /run/.containerenv),$(AWS_PLATFORM)))
 
     OCI_REGISTRY := docker.io/library
     OCI_IMG      := ruby
-    OCI_SHA256   := d4233f4242ea25346f157709bb8417c615e7478468e2699c8e86a4e1f0156de8 # 3.3.4-bookworm
+    OCI_SHA256   := d780a9b44dc5e57a4968d3e4b086bbdd9b595f06d747da10b29e568386fe1dd9 # 3.4.2-bookworm
     OCI_URI      := $(OCI_REGISTRY)/$(OCI_IMG)@sha256:$(OCI_SHA256)
 
     # Container engine (CRI) autodetect


### PR DESCRIPTION
Leveraging the latest, stable, official upstream Ruby OCI image: https://hub.docker.com/_/ruby

Removing the Gemfile.lock file prior to testing functionality via make(1)

**clean**
```
make clean
...
Fetching gem metadata from https://rubygems.org/.........
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll clean 
Configuration file: /srv/jekyll/_config.yml
           Cleaner: Nothing to do for /srv/jekyll/_site.
           Cleaner: Nothing to do for /srv/jekyll/.jekyll-metadata.
           Cleaner: Nothing to do for /srv/jekyll/.jekyll-cache.
           Cleaner: Nothing to do for .sass-cache.
Exiting 'podman' container engine! All parent recipes are no-op'd...
# /usr/local/bin/bundler cache
# /usr/local/bundle/bin/jekyll clean 
```

**deps**
```
make deps
...
Fetching gem metadata from https://rubygems.org/.........
Updating files in vendor/cache
Exiting 'podman' container engine! All parent recipes are no-op'd...
# /usr/local/bin/bundler cache
$ echo $?
0
```

**build**
```
make build
...
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll build 
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 0.358 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
Exiting 'podman' container engine! All parent recipes are no-op'd...
# /usr/local/bin/bundler cache
$ echo $?
0
```

**doctor**
```
make doctor
...
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll doctor 
Configuration file: /srv/jekyll/_config.yml
           Warning: You didn't set an URL in the config file, you may encounter problems with some plugins.
           Warning: Your site URL does not seem to be absolute, check the value of `url` in your config file.
make: *** [Makefile.jekyll:99: doctor] Error 1
make[1]: *** [Makefile.jekyll:86: _baremetal] Error 2
make: *** [Makefile:24: doctor] Error 2
$ echo $?
2
```

**serve**
```
make serve
...
Updating files in vendor/cache
/usr/local/bundle/bin/jekyll serve  --host 0.0.0.0 --force_polling --incremental
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: enabled
      Generating... 
                    done in 0.349 seconds.
/usr/local/bundle/gems/listen-3.9.0/lib/listen.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
 Auto-regeneration: enabled for '/srv/jekyll'
    Server address: http://0.0.0.0:4000/
  Server running... press ctrl-c to stop.
```